### PR TITLE
Allow arbitrary expander parameters, like (some-foo-expander x y . z).

### DIFF
--- a/private/expanders.rkt
+++ b/private/expanders.rkt
@@ -22,12 +22,12 @@
 (define (expander-stx? v)
   (and (syntax? v)
        (syntax-parse v
-         [(id:id _ ...) (expander? (maybe-syntax-local-value #'id))]
+         [(id:id . _) (expander? (maybe-syntax-local-value #'id))]
          [_ #f])))
 
 (define (expander-stx->expander expander-stx)
   (syntax-parse expander-stx
-    [(id:id _ ...) (maybe-syntax-local-value #'id)]))
+    [(id:id . _) (maybe-syntax-local-value #'id)]))
 
 (define (expander-stx-of-type? type v)
   (and (expander-stx? v)

--- a/test/test-call-with-dotted-last.rkt
+++ b/test/test-call-with-dotted-last.rkt
@@ -1,0 +1,22 @@
+#lang racket
+
+(require generic-syntax-expanders
+         (for-syntax syntax/parse)
+         rackunit)
+
+(define-expander-type foo)
+
+(define-foo-expander some-foo-expander
+  (syntax-parser
+    [(_ a:id b:id c:id . d:id) #'(d c b a)]))
+
+(define-syntax (test-foo-expander stx)
+  (syntax-parse stx
+    [(_ e:expr)
+     #`'#,(expand-all-foo-expanders #'e)]))
+
+(test-equal?
+ "Check that some-foo-expander accepts being called
+ when it is the first item of a dotted list"
+ (test-foo-expander (some-foo-expander x y z . t))
+ '(t z y x))


### PR DESCRIPTION
The previous pattern for a match expander was `(id:id _ ...)` which rejects the syntax before the `some-foo-expander` itself has a chance of seeing it. I replaced the pattern with `(id:id . _)`, and added a test case.
